### PR TITLE
set hdx key via value instead of file.

### DIFF
--- a/hdx/configuration.py
+++ b/hdx/configuration.py
@@ -98,9 +98,12 @@ class Configuration(dict_class,object):
 
         self.hdx_read_only = kwargs.get('hdx_read_only', False)
         if not self.hdx_read_only:
-            hdx_key_file = kwargs.get('hdx_key_file', join(expanduser('~'), '.hdxkey'))
-            """ :type : str"""
-            self.data['api_key'] = self.load_api_key(hdx_key_file)
+            if 'hdx_key' in kwargs:
+                self.data['api_key'] = kwargs.get('hdx_key')
+            else:
+                hdx_key_file = kwargs.get('hdx_key_file', join(expanduser('~'), '.hdxkey'))
+                """ :type : str"""
+                self.data['api_key'] = self.load_api_key(hdx_key_file)
 
         self.hdx_site = 'hdx_%s_site' % kwargs.get('hdx_site', 'test')
         if self.hdx_site not in self.data:

--- a/tests/hdx/test_configuration.py
+++ b/tests/hdx/test_configuration.py
@@ -310,3 +310,9 @@ class TestConfiguration:
         assert actual_configuration.get_api_key() == '12345'
         assert actual_configuration.get_hdx_site_url() == 'https://data.humdata.org/'
         assert actual_configuration._get_credentials() == ('', '')
+
+    def test_set_hdx_key_value(self, project_config_yaml):
+        actual_configuration = Configuration.create(hdx_site='prod', hdx_key="TEST_HDX_KEY",
+                                                    hdx_config_dict={},
+                                                    project_config_yaml=project_config_yaml)
+        assert actual_configuration.get_api_key() == 'TEST_HDX_KEY'


### PR DESCRIPTION
This is useful if you are running an application in a server environment with limited access to the filesystem, and want to configure the HDX_KEY via an environment variable